### PR TITLE
create patch script to bump go-getter from v1.7.4 to v1.7.5

### DIFF
--- a/patches-v0.51.4/92-go-getter.script
+++ b/patches-v0.51.4/92-go-getter.script
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cd "$1"
+
+PATCH_GO_VERSION=$(egrep '^go ' go.mod | awk '{print $2}' | sed -e 's+^\([0-9]*\.[0-9]*\)[^0-9]*.*$+\1+')
+PATCH_GO_PATH="$(ls -d ${RUNNER_TOOL_CACHE}/go/${PATCH_GO_VERSION}.*/*/bin)"
+export PATH="${PATH}:${PATCH_GO_PATH}"
+
+echo "Bumping go-getter dependency to fix CVE-2024-6257"
+
+go get \
+   github.com/hashicorp/go-getter@v1.7.5


### PR DESCRIPTION
## Description
This PR bumps go-getter dependency from v1.7.4 to v1.7.5 to fix CVE-2024-6257
